### PR TITLE
Add connect_to_browser for working with browser server

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,20 +12,33 @@ pip install git+https://github.com/YusukeIwaki/playwright-python-remote
 
 ## Example
 
+For communicating with Playwright server:
+
 ```py
 from playwright_remote.sync_api import sync_playwright_remote
 
 with sync_playwright_remote('ws://127.0.0.1:8080/ws') as playwright:
-  browser = playwright.chromium.launch()
-  try:
+  with playwright.chromium.launch() as browser:
     page = browser.new_page()
     page.goto('https://github.com/YusukeIwaki')
     page.screenshot(path='YusukeIwaki.png')
-  finally:
-    browser.close()
 ```
 
 Just replace `sync_playwright` with `sync_playwright_remote('ws://xxxxxxx/ws')`.
+
+---
+
+For communicating with Playwright Browser server:
+
+```py
+from playwright_remote.sync_api import connect_to_browser
+
+with connect_to_browser('ws://127.0.0.1:xxxxx/xxxxxxxxxxxxxxxxxxxxxx') as browser:
+  page = browser.new_page()
+  page.goto('https://github.com/YusukeIwaki')
+  page.screenshot(path='YusukeIwaki.png')
+```
+
 
 ### Launch Playwright server
 
@@ -34,7 +47,7 @@ We have to prepare Playwright server using playwright CLI.
 In local development environment (Node.js is required), just execute:
 
 ```
-npx playwright@1.12.3 install && npx playwright@1.12.3 run-server
+npx playwright@1.14.0 install && npx playwright@1.14.0 run-server
 ```
 
 For deploying to PaaS servers, we can use Playwright official Docker image: https://hub.docker.com/_/microsoft-playwright
@@ -49,6 +62,29 @@ CMD ["./node_modules/.bin/playwright", "run-server"]
 
 Heroku example can be found [here](https://github.com/YusukeIwaki/playwright-python-playWithWebSocket/blob/main/heroku.yml).
 
+### Launch Playwright Browser server
+
+We can also share only one browser environment via WebSocket.
+
+```
+npx playwright@1.14.0 install && npx playwright@1.14.0 launch-server firefox
+```
+
+Note that the functionality of CLI for launch-server is not so rich.
+For sharing more detailed environment, we have to prepare JavaScript server code like below:
+
+```js
+const playwright = require('playwright')
+
+// https://playwright.dev/docs/api/class-browsertype/#browser-type-launch-server
+option = {
+  channel: 'chrome-canary',
+  headless: false,
+  port: 8080,
+}
+playwright.chromium.launchServer(option).then((server) => { console.log(server.wsEndpoint()) })
+```
+
 ### Execute Python script on Alpine Linux environment
 
 Since playwright-remote works on Pure-Python environment, it works also on Alpine Linux.
@@ -59,7 +95,7 @@ Unfortunately, `pip install playwright` cannot be executed on Alpine. We have to
 FROM python:3.9-alpine
 
 RUN apk add --no-cache --virtual .install-deps build-base curl git \
-    && pip install git+https://github.com/microsoft/playwright-python@v1.12.1 \
+    && pip install git+https://github.com/microsoft/playwright-python@v1.14.0 \
     && pip install git+https://github.com/YusukeIwaki/playwright-python-remote \
     && apk del .install-deps
 ```

--- a/playwright_remote/sync_api/__init__.py
+++ b/playwright_remote/sync_api/__init__.py
@@ -1,5 +1,7 @@
 from playwright_remote.sync_api.sync_playwright_remote import sync_playwright_remote
+from playwright_remote.sync_api.connect_to_browser import connect_to_browser
 
 __all__ = [
+    "connect_to_browser",
     "sync_playwright_remote",
 ]

--- a/playwright_remote/sync_api/connect_to_browser.py
+++ b/playwright_remote/sync_api/connect_to_browser.py
@@ -1,0 +1,101 @@
+import asyncio
+from typing import Any, Dict, cast
+
+from greenlet import greenlet
+
+from playwright._impl._api_types import Error
+from playwright._impl._browser import Browser as BrowserImpl
+from playwright._impl._connection import Connection, from_channel
+from playwright._impl._object_factory import create_remote_object
+from playwright._impl._playwright import Playwright as PlaywrightImpl
+from playwright._impl._transport import WebSocketTransport
+from playwright.sync_api._generated import Browser as SyncBrowser
+
+
+class ConnectToBrowserContextManager:
+    def __init__(
+        self,
+        ws_endpoint: str,
+        slow_mo: float = None,
+        headers: Dict[str, str] = None,
+    ) -> None:
+        self._browser: SyncBrowser
+        self._ws_endpoint = ws_endpoint
+        self._slow_mo = slow_mo
+        self._headers = headers
+
+    def __enter__(self) -> SyncBrowser:
+        loop: asyncio.AbstractEventLoop
+        own_loop = None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            loop = asyncio.new_event_loop()
+            own_loop = loop
+        if loop.is_running():
+            raise Error(
+                """It looks like you are using Playwright Sync API inside the asyncio loop.
+Please use the Async API instead."""
+            )
+
+        def greenlet_main() -> None:
+            loop.run_until_complete(self._connection.run_as_sync())
+
+            if own_loop:
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.close()
+
+        dispatcher_fiber = greenlet(greenlet_main)
+        transport = WebSocketTransport(
+            loop,
+            self._ws_endpoint,
+            self._headers,
+            self._slow_mo)
+        self._connection = Connection(
+            dispatcher_fiber,
+            create_remote_object,
+            transport)
+
+        g_self = greenlet.getcurrent()
+
+        def callback_wrapper(playwright_impl: PlaywrightImpl) -> None:
+            self._playwright_impl = playwright_impl
+            g_self.switch()
+
+        self._connection.call_on_object_with_known_name(
+            "Playwright", callback_wrapper)
+
+        dispatcher_fiber.switch()
+
+        pre_launched_browser = self._playwright_impl._initializer.get(
+            "preLaunchedBrowser")
+        assert pre_launched_browser
+        browser = cast(BrowserImpl, from_channel(pre_launched_browser))
+        browser._is_remote = True
+        browser._is_connected_over_websocket = True
+
+        def handle_transport_close() -> None:
+            for context in browser.contexts:
+                for page in context.pages:
+                    page._on_close()
+                context._on_close()
+            browser._on_close()
+
+        transport.once("close", handle_transport_close)
+
+        self._browser = SyncBrowser(browser)
+        return self._browser
+
+    def start(self) -> SyncBrowser:
+        return self.__enter__()
+
+    def __exit__(self, *args: Any) -> None:
+        self._browser.close()
+
+
+def connect_to_browser(
+    ws_endpoint: str,
+    slow_mo: float = None,
+    headers: Dict[str, str] = None,
+) -> SyncBrowser:
+    return ConnectToBrowserContextManager(ws_endpoint, slow_mo, headers)


### PR DESCRIPTION
closes #1
refs: microsoft/playwright-python#732

Browser server:

```js
const playwright = require('playwright')

option = {
  channel: 'chrome-canary',
  headless: false,
  port: 8080,
}
playwright.chromium.launchServer(option).then((server) => { console.log(server.wsEndpoint()) })
```

client:

```python
from playwright_remote.sync_api import connect_to_browser

with connect_to_browser('ws://127.0.0.1:8080/xxxxxxxxxxxxxxxxxxxxxxxx') as browser:
    page = browser.new_page()
    page.goto('https://github.com/YusukeIwaki')
    page.screenshot(path='YusukeIwaki.png')
```

(client can be run on Alpine Linux.)